### PR TITLE
Array.prototype.find expects a boolean

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -309,7 +309,7 @@ function removeEventListener(target, evtName, callback) {
   eventsByTypeAndTarget[evtName][target] = eventsByTypeAndTarget[evtName][target] || {};
   const evts = eventsByTypeAndTarget[evtName][target];
   const idx = Object.keys(evts).find((evtIndex) => {
-    evts[evtIndex] === callback;
+    return evts[evtIndex] === callback;
   });
   delete evts[idx];
   queue.push([Commands.removeEventListener, target, evtName, index]);


### PR DESCRIPTION
I'm currently transforming your code into TypeScript and just stumbled upon a warning message regarding a missing return value. 

According to MDN the *find* method from Array expects a **boolean** value to be returned.

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/find

I didn't do any tests as I'm still trying to figure out how the code works internally.

I hope this PR isn't introducing any additional problems.

Kind regards,
Harris