### PR TITLE
common.js has no exported member 'EventAttributes'

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -1,4 +1,4 @@
-import {Node, Commands, Constants, MessagesQueue, EventAttributes, EventDOMNodeAttributes, Pipe}  from './common'
+import {Node, Commands, Constants, MessagesQueue, EventDOMNodeAttributes, Pipe}  from './common'
 class LocalContainer {
   constructor(queueIndex, domElement, name) {
     this.domElement = domElement;


### PR DESCRIPTION
It seems to be **unused** throughout the source code. 
Therefore, I assume it can be safely removed from the import list in *local.js*

Regards,